### PR TITLE
Escape bug

### DIFF
--- a/lib/markdown-to-react-loader.js
+++ b/lib/markdown-to-react-loader.js
@@ -32,7 +32,7 @@ function processCodeBlock (code, lang) {
   // users can easily type in any language they want,
   // we don't want the app to blow up in case of bad input.
   try {
-    if (typeof lang === 'undefined') {
+    if (!lang) {
       className = '';
       highlighter = '';
     } else {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "author": "Jon Sakas <jon.sakas@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "front-matter": "^2.1.2",
-    "marked": "^0.3.12",
-    "prismjs": "^1.10.0"
+    "front-matter": "^3.0.2",
+    "marked": "^0.7.0",
+    "prismjs": "^1.17.1"
   },
   "peerDependencies": {
     "react": "^16.2"

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -53,3 +53,7 @@ test('Converts tables and table cells', () => {
 test('Can render everything', () => {
   expectIO('io/everything.md', 'io/everything.js');
 });
+
+test('Allows inline JSX', () => {
+  expectIO('io/jsx.md', 'io/jsx.js');
+});

--- a/test/io/everything.js
+++ b/test/io/everything.js
@@ -180,7 +180,7 @@ const Markdown = () => (
       and code blocks:
     </p>
     <blockquote>
-      <h2 id="this-is-a-header-">This is a header.</h2>
+      <h2 id="this-is-a-header">This is a header.</h2>
       <ol>
         <li>This is the first list item.</li>
         <li>This is the second list item.</li>

--- a/test/io/jsx.js
+++ b/test/io/jsx.js
@@ -2,7 +2,8 @@ import React, { Fragment } from "react";
 
 const Markdown = () => (
   <Fragment>
-    <div style={{ width: '500px', display: 'flex' }}>JSX</div>
+    <h1 id="jsx">JSX</h1>
+    <div style={{ width: "500px", display: "flex" }}>JSX</div>
   </Fragment>
 );
 export default Markdown;

--- a/test/io/jsx.js
+++ b/test/io/jsx.js
@@ -1,0 +1,8 @@
+import React, { Fragment } from "react";
+
+const Markdown = () => (
+  <Fragment>
+    <div style={{ width: '500px', display: 'flex' }}>JSX</div>
+  </Fragment>
+);
+export default Markdown;

--- a/test/io/jsx.md
+++ b/test/io/jsx.md
@@ -1,0 +1,3 @@
+# JSX
+
+<div style={{ width: '500px', display: 'flex' }}>JSX</div>

--- a/test/io/simple.js
+++ b/test/io/simple.js
@@ -2,7 +2,7 @@ import React, { Fragment } from "react";
 
 const Markdown = () => (
   <Fragment>
-    <h1 id="hello-world-">Hello, World!</h1>
+    <h1 id="hello-world">Hello, World!</h1>
     <p>Its great to be here!</p>
   </Fragment>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,11 +1167,12 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-front-matter@^2.1.2:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-2.3.0.tgz#7203af896ce357ee04e2aa45169ea91ed7f67504"
+front-matter@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-3.0.2.tgz#2401cd05fcf22bd0de48a104ffb4efb1ff5c8465"
+  integrity sha512-iBGZaWyzqgsrPGsqrXZP6N4hp5FzSKDi18nfAoYpgz3qK5sAwFv/ojmn3VS60SOgLvq6CtojNqy0y6ZNz05IzQ==
   dependencies:
-    js-yaml "^3.10.0"
+    js-yaml "^3.13.1"
 
 fs-minipass@^1.2.5:
   version "1.2.6"
@@ -2003,7 +2004,7 @@ jest@^24.8.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.10.0:
+js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -2213,9 +2214,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.3.12:
-  version "0.3.19"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 mem@^4.0.0:
   version "4.3.0"
@@ -2729,9 +2731,10 @@ pretty-format@^24.8.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-prismjs@^1.10.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.15.0.tgz#8801d332e472091ba8def94976c8877ad60398d9"
+prismjs@^1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.17.1.tgz#e669fcbd4cdd873c35102881c33b14d0d68519be"
+  integrity sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==
   optionalDependencies:
     clipboard "^2.0.0"
 


### PR DESCRIPTION
Fix loader failing on inline JSX.

Seems to be resolved by simply updating dependencies. 

Closes https://github.com/jsakas/markdown-to-react-loader/issues/7