### PR TITLE
JSX complaint checkboxes

### DIFF
--- a/lib/markdown-to-react-loader.js
+++ b/lib/markdown-to-react-loader.js
@@ -16,6 +16,8 @@ function replaceReact(string) {
   return string
     .replace(regex, m => singleReplaceChars[m])
     .replace(/class="/g, 'className="')
+    .replace(/checked=""/g, "checked")
+    .replace(/disabled=""/g, "disabled")
 }
 
 const reactSafe = (fn) => {

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -57,3 +57,7 @@ test('Can render everything', () => {
 test('Allows inline JSX', () => {
   expectIO('io/jsx.md', 'io/jsx.js');
 });
+
+test('Makes checkboxes read-only', () => {
+  expectIO('io/taskListItems.md', 'io/taskListItems.js');
+});

--- a/test/io/taskListItems.js
+++ b/test/io/taskListItems.js
@@ -1,0 +1,15 @@
+import React, { Fragment } from "react";
+
+const Markdown = () => (
+  <Fragment>
+    <ul>
+      <li>
+        <input disabled type="checkbox" /> unchecked
+      </li>
+      <li>
+        <input checked disabled type="checkbox" /> checked
+      </li>
+    </ul>
+  </Fragment>
+);
+export default Markdown;

--- a/test/io/taskListItems.md
+++ b/test/io/taskListItems.md
@@ -1,0 +1,2 @@
+- [ ] unchecked
+- [x] checked


### PR DESCRIPTION
Marked added empty values (`=""`) to `checked` and `disabled`, something React couldn't handle. I've added rules to the `replaceReact` function that removes them in a similar way that `class="` is handled.

I also wrote a test, but couldn't get any of them to run correctly.<details>
<summary>To me it seems like jest might be doing something funny. (See screenshot.)</summary>

![image](https://user-images.githubusercontent.com/15267120/107880330-53a43e80-6ede-11eb-9248-07292804cfa6.png)

</details>